### PR TITLE
Update Dr Andrew Lee’s  title to read “Assoc Prof” instead of “Prof” 

### DIFF
--- a/_who-we-are/Advisory Committee On Accounting Standards for Statutory Boards.md
+++ b/_who-we-are/Advisory Committee On Accounting Standards for Statutory Boards.md
@@ -49,7 +49,7 @@ To bring wider representation and experience into the standards setting process,
         <img src="/images/Images/Default%20Source/Who%20We%20Are/andrew-lee-20230321-1-latest.jpg" alt="Professor Andrew Lee">
     </div>
     <div class="col is-8">
-        <p class="title is-4">Professor Andrew Lee</p>
+        <p class="title is-4">Assoc Prof Andrew Lee</p>
         <strong>Associate Professor </strong>
         <br> Singapore Management University            </div>
 </div>


### PR DESCRIPTION
To update Dr Andrew Lee’s  title to read “Assoc Prof” instead of “Prof” in the following link: https://www.assb.gov.sg/who-we-are/advisory-committee-on-accounting-standards-for-statutory-boards/.